### PR TITLE
smiles2sdf stops at invalid SMILE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ChemmineR
 Type: Package
 Title: Cheminformatics Toolkit for R
-Version: 3.53.2
+Version: 3.53.3
 Date: 2023-07-13
 Author: Y. Eddie Cao, Kevin Horan, Tyler Backman, Thomas Girke
 Maintainer: Thomas Girke <thomas.girke@ucr.edu>

--- a/R/sim.R
+++ b/R/sim.R
@@ -878,16 +878,52 @@ sdf2smiles <- sdf2smilesOB
 
 
 smiles2sdfOB <- function(smiles) {
-    if(!any(class(smiles) %in% c("character", "SMIset"))){
-        stop('input must be SMILES strings stored as \"SMIset\" or \"character\" object')
-    }
-	 if(inherits(smiles,"SMIset")) smiles <- as.character(smiles)
-	 .ensureOB()
-	 sdf = definition2SDFset(convertFormat("SMI","SDF",paste(paste(smiles,names(smiles),sep="\t"), collapse="\n")))
-	 cid(sdf)=sdfid(sdf)
-	 sdf
+  if (!any(class(smiles) %in% c("character", "SMIset"))) {
+    stop('input must be SMILES strings stored as \"SMIset\" or \"character\" object')
+  }
+  if (inherits(smiles, "SMIset")) smiles <- as.character(smiles)
+  .ensureOB()
+
+  text_def <- ChemmineOB::convertFormat(
+    from = "SMI",
+    to = "SDF",
+    source = paste(paste(smiles, names(smiles), sep = "\t"), collapse = "\n")
+  )
+  # OpenBabel may stop at conversion errors
+  if (text_def == "") {
+    # First one failed, return an empty SDF
+    return(new("SDFset"))
+  }
+  sdf <- definition2SDFset(text_def)
+  cid(sdf) <- sdfid(sdf)
+  sdf
 }
-smiles2sdf <- smiles2sdfOB
+
+smiles2sdf <- function(smiles) {
+  i <- 0  # length of processed smiles 
+  j <- length(smiles)
+
+  # initialize empty SDFset
+  sdfset <- new("SDFset")
+
+  # OpenBabel may stop at conversion errors, process chunks if needed
+  while (i < j) {
+    # converted sdfset, truncated before first failing smile
+    new_sdfs <- smiles2sdfOB(smiles[(i+1):j])
+    k <- length(new_sdfs)
+    if (k > 0) {
+      sdfset <- c(sdfset, new_sdfs)
+      i <- i + k
+    }
+    # skip failed molecule in SDFset
+    if (i < j) {
+      i <- i + 1
+      warning("Could not convert ", names(smiles)[i], "'. Skipping.")
+    }
+  }
+  sdfset
+}
+
 
 regenCoordsOB <- function(sdf){
 	applyOptions(sdf,data.frame(names="gen2D",args=""))

--- a/inst/unitTests/test_general.R
+++ b/inst/unitTests/test_general.R
@@ -18,6 +18,38 @@ test.formatConversions <- function() {
 
 }
 
+test.invalidSmileParsing <- function() {
+  smiles <- c(
+    Caffein = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C",
+    FailingSmile1 = "C1CCCCC",
+    FailingSmile2 = "CS(=O)=OG",
+    Fructose = "O[C@H]1[C@H](O)[C@H](O[C@]1(O)CO)CO"
+  )
+  sdfs <- smiles2sdf(smiles)
+  checkTrue(all(validSDF(sdfs)))
+  checkEquals(length(sdfs), 2)
+  checkTrue("Caffein" %in% sdfs@ID)
+  checkTrue("Fructose" %in% sdfs@ID)
+
+  # fail first
+  sdfs <- smiles2sdf(smiles[c(2, 3, 1, 4)])
+  checkTrue(all(validSDF(sdfs)))
+  checkEquals(length(sdfs), 2)
+  checkTrue("Caffein" %in% sdfs@ID)
+  checkTrue("Fructose" %in% sdfs@ID)
+
+  # fail last
+  sdfs <- smiles2sdf(smiles[c(1, 4, 2, 3)])
+  checkTrue(all(validSDF(sdfs)))
+  checkEquals(length(sdfs), 2)
+  checkTrue("Caffein" %in% sdfs@ID)
+  checkTrue("Fructose" %in% sdfs@ID)
+
+  # fail all
+  sdfs <- smiles2sdf(smiles[c(2, 3)])
+  checkEquals(length(sdfs), 0)
+}
+
 test.genAPDescriptors <- function(){
 
 	DEACTIVATED("removed old version of function")


### PR DESCRIPTION
Closes #23.

I modified the `smiles2sdf` wrapper around `smiles2sdfOB` to iteratively call the Open Babel conversion until all SMILES are processed.  

Unlike I had suggested [here](https://github.com/girke-lab/ChemmineR/issues/23#issuecomment-2804156442) it does not insert `NULL` elements into the output SDFset for failing SMILES, as those `NULL` elements would cause `validSDF` to throw an error.

Let me know if you have any questions or suggestions :).

Best,
Steffi